### PR TITLE
fix line number in resources with no class/define

### DIFF
--- a/lib/puppet-lint/plugins/check_resource_outside_class.rb
+++ b/lib/puppet-lint/plugins/check_resource_outside_class.rb
@@ -40,7 +40,7 @@ PuppetLint.new_check(:resource_outside_class) do
       #no class and no defined type
       unless resource_list.length == 0
         notify :warning, {
-          :message => 'resourcss exist but no class or defined type definition found in manifest',
+          :message => 'resources exist but no class or defined type definition found in manifest',
           :line    => resource_list.first[:type].line,
           :column  => resource_list.first[:type].column,
         }

--- a/lib/puppet-lint/plugins/check_resource_outside_class.rb
+++ b/lib/puppet-lint/plugins/check_resource_outside_class.rb
@@ -41,8 +41,8 @@ PuppetLint.new_check(:resource_outside_class) do
       unless resource_list.length == 0
         notify :warning, {
           :message => 'resourcss exist but no class or defined type definition found in manifest',
-          :line    => resource_list.first[:line],
-          :column  => resource_list.first[:column],
+          :line    => resource_list.first[:type].line,
+          :column  => resource_list.first[:type].column,
         }
       end
     end

--- a/puppet-lint-resource_outside_class-check.gemspec
+++ b/puppet-lint-resource_outside_class-check.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
      A puppet-lint plugin to check that manifest files do not contain resources outside of a class or defined type definition.
    EOF
 
-   spec.add_dependency             'puppet-lint', '~> 1.0'
+   spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
    spec.add_development_dependency 'rspec', '~> 3.0'
    spec.add_development_dependency 'rspec-its', '~> 1.0'
    spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'

--- a/spec/puppet-lint/plugins/check_resource_outside_class_spec.rb
+++ b/spec/puppet-lint/plugins/check_resource_outside_class_spec.rb
@@ -4,7 +4,7 @@ describe 'resource_outside_class' do
 
   let(:class_msg) { 'resource found outside a class definition' }
   let(:define_msg) { 'resource found outside a defined type defintion' }
-  let(:no_class_or_define_msg) { 'resourcss exist but no class or defined type definition found in manifest' }
+  let(:no_class_or_define_msg) { 'resources exist but no class or defined type definition found in manifest' }
 
   context 'with fix disabled' do
 

--- a/spec/puppet-lint/plugins/check_resource_outside_class_spec.rb
+++ b/spec/puppet-lint/plugins/check_resource_outside_class_spec.rb
@@ -4,7 +4,7 @@ describe 'resource_outside_class' do
 
   let(:class_msg) { 'resource found outside a class definition' }
   let(:define_msg) { 'resource found outside a defined type defintion' }
-  let(no_class_or_define_msg) { 'resourcss exist but no class or defined type definition found in manifest')
+  let(:no_class_or_define_msg) { 'resourcss exist but no class or defined type definition found in manifest' }
 
   context 'with fix disabled' do
 


### PR DESCRIPTION
puppet-lint control comment ignores weren't working because of the missing line
number.

spec failed because of missing line number.

specs weren't working beause of a typo.
