### PR TITLE
fix: remove duplicate and false warnings when there are many class definitions inside .pp

### DIFF
--- a/lib/puppet-lint/plugins/check_resource_outside_class.rb
+++ b/lib/puppet-lint/plugins/check_resource_outside_class.rb
@@ -7,15 +7,18 @@ PuppetLint.new_check(:resource_outside_class) do
     bad_resource_list = resource_list.clone
 
     if class_indexes.length > 0
+    # The file has at least a class in it it
       class_list = class_indexes
 
       class_list.each do |cl|
         resource_list.each do |res|
+        # find all good resources
           if ( res[:start] > cl[:start] ) && ( res[:end] < cl[:end] )
               bad_resource_list.delete(res)
           end
         end
       end
+      
       bad_resource_list.each do |res|
         notify :warning,  {
           :message => "resource found outside a class definition ",

--- a/lib/puppet-lint/plugins/check_resource_outside_class.rb
+++ b/lib/puppet-lint/plugins/check_resource_outside_class.rb
@@ -7,12 +7,12 @@ PuppetLint.new_check(:resource_outside_class) do
     bad_resource_list = resource_list.clone
 
     if class_indexes.length > 0
-    # The file has at least a class in it it
+      # The file has at least a class in it it
       class_list = class_indexes
 
       class_list.each do |cl|
         resource_list.each do |res|
-        # find all good resources
+          # find all good resources
           if ( res[:start] > cl[:start] ) && ( res[:end] < cl[:end] )
               bad_resource_list.delete(res)
           end
@@ -20,8 +20,9 @@ PuppetLint.new_check(:resource_outside_class) do
       end
       
       bad_resource_list.each do |res|
+        # notify for all resource outside a class definition
         notify :warning,  {
-          :message => "resource found outside a class definition ",
+          :message => 'resource found outside a class definition',
           :line    => res[:type].line,
           :column  => res[:type].column,
         }

--- a/lib/puppet-lint/plugins/check_resource_outside_class.rb
+++ b/lib/puppet-lint/plugins/check_resource_outside_class.rb
@@ -4,22 +4,25 @@ PuppetLint.new_check(:resource_outside_class) do
     first_token = tokens.first
     last_token = tokens.last
     resource_list = resource_indexes
+    bad_resource_list = resource_list.clone
 
     if class_indexes.length > 0
-      # The file has at least a class in it it
       class_list = class_indexes
-      
+
       class_list.each do |cl|
         resource_list.each do |res|
-          unless ( res[:start] > cl[:start] ) && ( res[:end] < cl[:end] )
-            notify :warning,  {
-              :message => 'resource found outside a class definition',
-              :line    => res[:type].line,
-              :column  => res[:type].column,
-            }
+          if ( res[:start] > cl[:start] ) && ( res[:end] < cl[:end] )
+              bad_resource_list.delete(res)
           end
         end
       end
+      bad_resource_list.each do |res|
+        notify :warning,  {
+          :message => "resource found outside a class definition ",
+          :line    => res[:type].line,
+          :column  => res[:type].column,
+        }
+      end            
 
     elsif defined_type_indexes.length > 0
       #the file has at least a defined type in it
@@ -48,4 +51,3 @@ PuppetLint.new_check(:resource_outside_class) do
     end
   end
 end
-


### PR DESCRIPTION
1. check classes and resources
2. remove "good" resources from resource list
3. show only "bad" resources
